### PR TITLE
feat(blog): add MDX compilation pipeline

### DIFF
--- a/app/utils/blog/compile-mdx.server.ts
+++ b/app/utils/blog/compile-mdx.server.ts
@@ -1,0 +1,82 @@
+import { bundleMDX } from 'mdx-bundler'
+import PQueue from 'p-queue'
+import calculateReadingTime from 'reading-time'
+import { type GitHubFile, type Frontmatter, frontmatterSchema } from './types'
+
+async function compileMdx(slug: string, githubFiles: Array<GitHubFile>) {
+	const indexRegex = new RegExp(`${slug}\\/index.mdx?$`)
+	const indexFile = githubFiles.find(({ path }) => indexRegex.test(path))
+	if (!indexFile) return null
+
+	const rootDir = indexFile.path.replace(/index.mdx?$/, '')
+	const relativeFiles: Array<GitHubFile> = githubFiles.map(
+		({ path, content }) => ({
+			path: path.replace(rootDir, './'),
+			content,
+		}),
+	)
+	const files = arrayToObj(relativeFiles, {
+		keyName: 'path',
+		valueName: 'content',
+	})
+
+	try {
+		const { frontmatter, code } = await bundleMDX({
+			source: indexFile.content,
+			files,
+		})
+		const validatedFrontmatter = frontmatterSchema.parse(frontmatter)
+		const readTime = calculateReadingTime(indexFile.content)
+
+		return {
+			code,
+			readTime,
+			frontmatter: validatedFrontmatter satisfies Frontmatter,
+		}
+	} catch (error: unknown) {
+		console.error(`Compilation error for slug: `, slug)
+		throw error
+	}
+}
+
+function arrayToObj<ItemType extends Record<string, unknown>>(
+	array: Array<ItemType>,
+	{
+		keyName,
+		valueName,
+	}: { keyName: keyof ItemType; valueName: keyof ItemType },
+) {
+	const obj: Record<string, ItemType[keyof ItemType]> = {}
+	for (const item of array) {
+		const key = item[keyName]
+		if (typeof key !== 'string') {
+			throw new Error(`${String(keyName)} of item must be a string`)
+		}
+		const value = item[valueName]
+		obj[key] = value
+	}
+	return obj
+}
+
+let _queue: PQueue | null = null
+async function getQueue() {
+	if (_queue) return _queue
+
+	_queue = new PQueue({
+		concurrency: 1,
+		timeout: 1000 * 30,
+	})
+	return _queue
+}
+
+// We have to use a queue because we can't run more than one of these at a time
+// or we'll hit an out of memory error because esbuild uses a lot of memory...
+async function queuedCompileMdx(
+	...args: Parameters<typeof compileMdx>
+) {
+	const queue = await getQueue()
+	const result = await queue.add(() => compileMdx(...args))
+	return result
+}
+
+export { queuedCompileMdx as compileMdx }


### PR DESCRIPTION
## Summary
- Add `compileMdx(slug, files)` with PQueue (concurrency=1), Zod frontmatter validation, reading-time calculation
- Handles co-located files via relative path remapping
- No remark/rehype plugins yet (deferred to #19)

resolves #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)