### PR TITLE
feat(blog): add cached MDX content loading

### DIFF
--- a/app/utils/blog/mdx.server.ts
+++ b/app/utils/blog/mdx.server.ts
@@ -1,0 +1,206 @@
+import { format } from 'date-fns'
+import { type GitHubFile, type MdxPage, type MdxListItem } from './types.ts'
+import { compileMdx } from './compile-mdx.server.ts'
+import {
+	downloadDirList,
+	downloadMdxFileOrDirectory,
+} from './github.server.ts'
+import { cache, cachified } from '#app/utils/cache.server.ts'
+import { type Timings } from '#app/utils/timing.server.ts'
+
+type CachifiedOptions = {
+	forceFresh?: boolean | string
+	request?: Request
+	ttl?: number
+	timings?: Timings
+}
+
+const defaultTTL = 1000 * 60 * 60 * 24 * 14
+const defaultStaleWhileRevalidate = 1000 * 60 * 60 * 24 * 365 * 100
+
+const checkCompiledValue = (value: unknown) =>
+	typeof value === 'object' &&
+	(value === null || ('code' in value && 'frontmatter' in value))
+
+export async function getMdxPage(
+	{ slug }: { slug: string },
+	options: CachifiedOptions,
+): Promise<MdxPage | null> {
+	const { forceFresh, ttl = defaultTTL, request, timings } = options
+	const key = `mdx-page:blog:${slug}:compiled`
+	const page = await cachified({
+		key,
+		cache,
+		request,
+		timings,
+		ttl,
+		staleWhileRevalidate: defaultStaleWhileRevalidate,
+		forceFresh,
+		checkValue: checkCompiledValue,
+		getFreshValue: async () => {
+			const pageFiles = await downloadMdxFilesCached(slug, options)
+			const compiledPage = await compileMdxCached({
+				slug,
+				...pageFiles,
+				options,
+			}).catch((err) => {
+				console.error(`Failed to get a fresh value for mdx:`, { slug })
+				return Promise.reject(err)
+			})
+			return compiledPage
+		},
+	})
+	if (!page) {
+		void cache.delete(key)
+	}
+	return page
+}
+
+export async function getMdxPagesInDirectory(options: CachifiedOptions) {
+	const dirList = await getMdxDirList(options)
+
+	const pageDatas = await Promise.all(
+		dirList.map(async ({ slug }) => ({
+			...(await downloadMdxFilesCached(slug, options)),
+			slug,
+		})),
+	)
+
+	const pages = await Promise.all(
+		pageDatas.map((pageData) => compileMdxCached({ ...pageData, options })),
+	)
+	return pages.filter(Boolean) as Array<MdxPage>
+}
+
+export async function getMdxDirList(options?: CachifiedOptions) {
+	const { forceFresh, ttl = defaultTTL, request, timings } = options ?? {}
+	const key = 'blog:dir-list'
+	return cachified({
+		cache,
+		request,
+		timings,
+		ttl,
+		staleWhileRevalidate: defaultStaleWhileRevalidate,
+		forceFresh,
+		key,
+		checkValue: (value: unknown) => Array.isArray(value),
+		getFreshValue: async () => {
+			const fullContentDirPath = 'content/blog'
+			const dirList = (await downloadDirList(fullContentDirPath))
+				.map(({ name, path }) => ({
+					name,
+					slug: path
+						.replace(/\\/g, '/')
+						.replace(`${fullContentDirPath}/`, '')
+						.replace(/\.mdx$/, ''),
+				}))
+				.filter(({ name }) => name !== 'README.md')
+			return dirList
+		},
+	})
+}
+
+export async function getBlogMdxListItems(
+	options: CachifiedOptions,
+): Promise<Array<MdxListItem>> {
+	const { request, forceFresh, ttl = defaultTTL, timings } = options
+	const key = 'blog:mdx-list-items'
+	return cachified({
+		cache,
+		request,
+		timings,
+		ttl,
+		staleWhileRevalidate: defaultStaleWhileRevalidate,
+		forceFresh,
+		key,
+		getFreshValue: async () => {
+			let pages = await getMdxPagesInDirectory(options).then((allPosts) =>
+				allPosts.filter(
+					(p) => !p.frontmatter.draft && !p.frontmatter.unlisted,
+				),
+			)
+
+			pages = pages.sort((a, z) => {
+				const aTime = new Date(a.frontmatter.date ?? '').getTime()
+				const zTime = new Date(z.frontmatter.date ?? '').getTime()
+				return aTime > zTime ? -1 : aTime === zTime ? 0 : 1
+			})
+
+			return pages.map(({ code, ...rest }) => rest)
+		},
+	})
+}
+
+export async function downloadMdxFilesCached(
+	slug: string,
+	options: CachifiedOptions,
+) {
+	const { forceFresh, ttl = defaultTTL, request, timings } = options
+	const key = `blog:${slug}:downloaded`
+	const downloaded = await cachified({
+		cache,
+		request,
+		timings,
+		ttl,
+		staleWhileRevalidate: defaultStaleWhileRevalidate,
+		forceFresh,
+		key,
+		checkValue: (value: unknown) => {
+			if (typeof value !== 'object') return 'value is not an object'
+			if (value === null) return 'value is null'
+
+			const download = value as Record<string, unknown>
+			if (!Array.isArray(download.files)) return 'value.files is not an array'
+			if (typeof download.entry !== 'string')
+				return 'value.entry is not a string'
+
+			return true
+		},
+		getFreshValue: async () => downloadMdxFileOrDirectory(slug),
+	})
+	if (!downloaded.files.length) {
+		void cache.delete(key)
+	}
+	return downloaded
+}
+
+async function compileMdxCached({
+	slug,
+	entry,
+	files,
+	options,
+}: {
+	slug: string
+	entry: string
+	files: Array<GitHubFile>
+	options: CachifiedOptions
+}) {
+	const key = `mdx-page:blog:${slug}:compiled`
+	const page = await cachified({
+		cache,
+		ttl: defaultTTL,
+		staleWhileRevalidate: defaultStaleWhileRevalidate,
+		...options,
+		key,
+		checkValue: checkCompiledValue,
+		getFreshValue: async () => {
+			const compiledPage = await compileMdx(slug, files)
+			if (compiledPage) {
+				return {
+					dateDisplay: compiledPage.frontmatter.date
+						? format(new Date(compiledPage.frontmatter.date), 'PPP')
+						: undefined,
+					...compiledPage,
+					slug,
+					editLink: `https://github.com/M-Kolacz/michalkolacz.com/edit/master/${entry}`,
+				}
+			} else {
+				return null
+			}
+		},
+	})
+	if (!page) {
+		void cache.delete(key)
+	}
+	return page
+}

--- a/app/utils/blog/mdx.server.ts
+++ b/app/utils/blog/mdx.server.ts
@@ -1,15 +1,12 @@
 import { format } from 'date-fns'
-import { type GitHubFile, type MdxPage, type MdxListItem } from './types.ts'
-import { compileMdx } from './compile-mdx.server.ts'
-import {
-	downloadDirList,
-	downloadMdxFileOrDirectory,
-} from './github.server.ts'
 import { cache, cachified } from '#app/utils/cache.server.ts'
 import { type Timings } from '#app/utils/timing.server.ts'
+import { compileMdx } from './compile-mdx.server.ts'
+import { downloadDirList, downloadMdxFileOrDirectory } from './github.server.ts'
+import { type GitHubFile, type MdxPage, type MdxListItem } from './types.ts'
 
 type CachifiedOptions = {
-	forceFresh?: boolean | string
+	forceFresh?: boolean
 	request?: Request
 	ttl?: number
 	timings?: Timings
@@ -26,12 +23,11 @@ export async function getMdxPage(
 	{ slug }: { slug: string },
 	options: CachifiedOptions,
 ): Promise<MdxPage | null> {
-	const { forceFresh, ttl = defaultTTL, request, timings } = options
+	const { forceFresh, ttl = defaultTTL, timings } = options
 	const key = `mdx-page:blog:${slug}:compiled`
 	const page = await cachified({
 		key,
 		cache,
-		request,
 		timings,
 		ttl,
 		staleWhileRevalidate: defaultStaleWhileRevalidate,
@@ -73,11 +69,10 @@ export async function getMdxPagesInDirectory(options: CachifiedOptions) {
 }
 
 export async function getMdxDirList(options?: CachifiedOptions) {
-	const { forceFresh, ttl = defaultTTL, request, timings } = options ?? {}
+	const { forceFresh, ttl = defaultTTL, timings } = options ?? {}
 	const key = 'blog:dir-list'
 	return cachified({
 		cache,
-		request,
 		timings,
 		ttl,
 		staleWhileRevalidate: defaultStaleWhileRevalidate,
@@ -103,11 +98,10 @@ export async function getMdxDirList(options?: CachifiedOptions) {
 export async function getBlogMdxListItems(
 	options: CachifiedOptions,
 ): Promise<Array<MdxListItem>> {
-	const { request, forceFresh, ttl = defaultTTL, timings } = options
+	const { forceFresh, ttl = defaultTTL, timings } = options
 	const key = 'blog:mdx-list-items'
 	return cachified({
 		cache,
-		request,
 		timings,
 		ttl,
 		staleWhileRevalidate: defaultStaleWhileRevalidate,
@@ -115,9 +109,7 @@ export async function getBlogMdxListItems(
 		key,
 		getFreshValue: async () => {
 			let pages = await getMdxPagesInDirectory(options).then((allPosts) =>
-				allPosts.filter(
-					(p) => !p.frontmatter.draft && !p.frontmatter.unlisted,
-				),
+				allPosts.filter((p) => !p.frontmatter.draft && !p.frontmatter.unlisted),
 			)
 
 			pages = pages.sort((a, z) => {
@@ -135,11 +127,10 @@ export async function downloadMdxFilesCached(
 	slug: string,
 	options: CachifiedOptions,
 ) {
-	const { forceFresh, ttl = defaultTTL, request, timings } = options
+	const { forceFresh, ttl = defaultTTL, timings } = options
 	const key = `blog:${slug}:downloaded`
 	const downloaded = await cachified({
 		cache,
-		request,
 		timings,
 		ttl,
 		staleWhileRevalidate: defaultStaleWhileRevalidate,


### PR DESCRIPTION
## Summary
- Cachified wrapper around GitHub download + MDX compilation with dual-layer cache (LRU+SQLite)
- `getMdxPage()`, `getBlogMdxListItems()`, `downloadMdxFilesCached()`, `getMdxDirList()`
- Filters draft/unlisted posts, sorts by date, supports `forceFresh` param

resolves #12

## Test plan
- [ ] Verify `getMdxPage` returns compiled page with correct shape
- [ ] Verify `getBlogMdxListItems` filters draft/unlisted and sorts by date
- [ ] Verify caching works (second call skips GitHub)
- [ ] Verify `forceFresh` bypasses cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)