### PR TITLE
feat(blog): add blog index and post routes

### DIFF
--- a/app/routes/_layout.blog.tsx
+++ b/app/routes/_layout.blog.tsx
@@ -1,0 +1,47 @@
+import { Link, useLoaderData } from 'react-router'
+import { type MetaFunction } from 'react-router'
+import { getBlogMdxListItems } from '#app/utils/blog/mdx.server.ts'
+
+export const meta: MetaFunction = () => [{ title: 'Blog | Michal Kolacz' }]
+
+export async function loader() {
+	const posts = await getBlogMdxListItems({})
+	return { posts }
+}
+
+export default function BlogIndex() {
+	const { posts } = useLoaderData<typeof loader>()
+
+	return (
+		<main className="container py-12">
+			<h2 className="text-h2 mb-12">Blog</h2>
+			{posts.length === 0 ? (
+				<p className="text-muted-foreground">No posts yet.</p>
+			) : (
+				<ul className="flex flex-col gap-8">
+					{posts.map((post) => (
+						<li key={post.slug}>
+							<Link
+								to={`/blog/${post.slug}`}
+								className="group block"
+							>
+								<h3 className="text-xl font-bold group-hover:underline">
+									{post.frontmatter.title}
+								</h3>
+								<p className="text-muted-foreground mt-1 text-sm">
+									{post.dateDisplay}
+									{post.readTime ? ` · ${post.readTime.text}` : null}
+								</p>
+								{post.frontmatter.description ? (
+									<p className="mt-2">
+										{post.frontmatter.description}
+									</p>
+								) : null}
+							</Link>
+						</li>
+					))}
+				</ul>
+			)}
+		</main>
+	)
+}

--- a/app/routes/_layout.blog_.$slug.tsx
+++ b/app/routes/_layout.blog_.$slug.tsx
@@ -1,0 +1,46 @@
+import { getMDXComponent } from 'mdx-bundler/client'
+import { useMemo } from 'react'
+import { data, useLoaderData } from 'react-router'
+import { type MetaFunction, type LoaderFunctionArgs } from 'react-router'
+import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
+import { getMdxPage } from '#app/utils/blog/mdx.server.ts'
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+	if (!data) return [{ title: 'Post Not Found | Michal Kolacz' }]
+	return [
+		{ title: `${data.page.frontmatter.title} | Michal Kolacz` },
+		{ name: 'description', content: data.page.frontmatter.description },
+	]
+}
+
+export async function loader({ params }: LoaderFunctionArgs) {
+	const slug = params.slug
+	if (!slug) throw data('Not found', { status: 404 })
+
+	const page = await getMdxPage({ slug }, {})
+	if (!page) throw data('Not found', { status: 404 })
+
+	return { page }
+}
+
+export default function BlogPost() {
+	const { page } = useLoaderData<typeof loader>()
+	const Component = useMemo(() => getMDXComponent(page.code), [page.code])
+
+	return (
+		<main className="container py-12">
+			<header className="mb-12">
+				<h2 className="text-h2">{page.frontmatter.title}</h2>
+				<p className="text-muted-foreground mt-2 text-sm">
+					{page.dateDisplay}
+					{page.readTime ? ` · ${page.readTime.text}` : null}
+				</p>
+			</header>
+			<article>
+				<Component />
+			</article>
+		</main>
+	)
+}
+
+export const ErrorBoundary = GeneralErrorBoundary

--- a/content/blog/hello-world/index.mdx
+++ b/content/blog/hello-world/index.mdx
@@ -1,0 +1,13 @@
+---
+title: Hello World
+description: My first blog post
+date: '2026-02-21'
+---
+
+# Hello World
+
+Welcome to my blog! This is a test post to verify the blog routes work correctly.
+
+## What's next?
+
+Stay tuned for more content.


### PR DESCRIPTION
## Summary
- Add `/blog` index route with plain list of posts (title, date, reading time, description)
- Add `/blog/:slug` post route with MDX rendering and 404 handling
- Add test blog post for verification

Resolves #13

## Test plan
- [ ] Navigate to `/blog` — see list of posts
- [ ] Click a post — `/blog/:slug` renders content
- [ ] Navigate to `/blog/nonexistent` — 404 error page
- [ ] Verify light/dark mode styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)