### PR TITLE
feat(blog): client-side MDX rendering + custom components

### DIFF
--- a/app/routes/_layout.blog_.$slug.tsx
+++ b/app/routes/_layout.blog_.$slug.tsx
@@ -1,8 +1,7 @@
-import { getMDXComponent } from 'mdx-bundler/client'
-import { useMemo } from 'react'
 import { data, useLoaderData } from 'react-router'
 import { type MetaFunction, type LoaderFunctionArgs } from 'react-router'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
+import { useMdxComponent } from '#app/utils/blog/mdx-components.tsx'
 import { getMdxPage } from '#app/utils/blog/mdx.server.ts'
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
@@ -25,7 +24,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
 
 export default function BlogPost() {
 	const { page } = useLoaderData<typeof loader>()
-	const Component = useMemo(() => getMDXComponent(page.code), [page.code])
+	const Component = useMdxComponent(page.code)
 
 	return (
 		<main className="container py-12">
@@ -36,7 +35,7 @@ export default function BlogPost() {
 					{page.readTime ? ` · ${page.readTime.text}` : null}
 				</p>
 			</header>
-			<article>
+			<article className="prose dark:prose-invert max-w-none">
 				<Component />
 			</article>
 		</main>

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
+@import 'tailwindcss/typography';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -1,6 +1,6 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
-@import 'tailwindcss/typography';
+@plugin '@tailwindcss/typography';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/utils/blog/mdx-components.tsx
+++ b/app/utils/blog/mdx-components.tsx
@@ -1,0 +1,61 @@
+import { getMDXComponent } from 'mdx-bundler/client'
+import { useMemo } from 'react'
+import { cn } from '#app/utils/misc.tsx'
+
+const mdxComponentCache = new Map<
+	string,
+	ReturnType<typeof getMdxComponent>
+>()
+
+function getMdxComponent(code: string) {
+	const Component = getMDXComponent(code)
+	function MdxComponent({
+		components,
+		...rest
+	}: Parameters<typeof Component>['0']) {
+		return (
+			<Component components={{ ...mdxComponents, ...components }} {...rest} />
+		)
+	}
+	return MdxComponent
+}
+
+export function useMdxComponent(code: string) {
+	return useMemo(() => {
+		if (mdxComponentCache.has(code)) {
+			return mdxComponentCache.get(code)!
+		}
+		const component = getMdxComponent(code)
+		mdxComponentCache.set(code, component)
+		return component
+	}, [code])
+}
+
+function Callout({
+	children,
+	variant = 'info',
+}: {
+	children: React.ReactNode
+	variant?: 'info' | 'warning' | 'danger' | 'success'
+}) {
+	return (
+		<div
+			className={cn(
+				'my-6 rounded-lg border-l-4 p-4',
+				variant === 'info' && 'border-blue-500 bg-blue-50 dark:bg-blue-950/30',
+				variant === 'warning' &&
+					'border-yellow-500 bg-yellow-50 dark:bg-yellow-950/30',
+				variant === 'danger' &&
+					'border-red-500 bg-red-50 dark:bg-red-950/30',
+				variant === 'success' &&
+					'border-green-500 bg-green-50 dark:bg-green-950/30',
+			)}
+		>
+			{children}
+		</div>
+	)
+}
+
+const mdxComponents = {
+	Callout,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@sentry/react-router": "^10.38.0",
         "@simplewebauthn/browser": "^13.2.2",
         "@simplewebauthn/server": "^13.2.2",
+        "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.18",
         "@tusbar/cache-control": "^2.0.0",
         "address": "^2.0.3",
@@ -8107,6 +8108,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.18.tgz",
@@ -11395,6 +11408,18 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/cssstyle": {
       "version": "5.3.7",
@@ -18313,6 +18338,19 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -22151,7 +22189,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@sentry/react-router": "^10.38.0",
     "@simplewebauthn/browser": "^13.2.2",
     "@simplewebauthn/server": "^13.2.2",
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.18",
     "@tusbar/cache-control": "^2.0.0",
     "address": "^2.0.3",


### PR DESCRIPTION
## Summary
- Install `@tailwindcss/typography` for prose styling
- Add `useMdxComponent` hook with component caching + `Callout` custom component
- Integrate hook + `prose dark:prose-invert` classes in blog post route

resolves #14

## Test plan
- [ ] Navigate to blog post, verify prose styling applied
- [ ] Check browser console for hydration errors
- [ ] Test Callout component in MDX content
- [ ] Verify dark mode prose styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)