### PR TITLE
Blog: UI polish + error handling

### DIFF
--- a/app/routes/_layout.blog.tsx
+++ b/app/routes/_layout.blog.tsx
@@ -42,7 +42,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 		if (userId) {
 			const user = await prisma.user.findUnique({
 				where: { id: userId },
-				select: { roles: { select: { name: true } } },
+				include: { roles: { select: { name: true, permissions: true } } },
 			})
 			showDrafts = userHasRole(user, 'admin')
 		}

--- a/app/routes/_layout.blog.tsx
+++ b/app/routes/_layout.blog.tsx
@@ -1,5 +1,10 @@
-import { Link, useLoaderData, useNavigation } from 'react-router'
-import { type MetaFunction, type LoaderFunctionArgs } from 'react-router'
+import {
+	Link,
+	useLoaderData,
+	useNavigation,
+	type MetaFunction,
+	type LoaderFunctionArgs,
+} from 'react-router'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
 import { Skeleton } from '#app/components/ui/skeleton.tsx'
 import { getUserId } from '#app/utils/auth.server.ts'

--- a/app/routes/_layout.blog.tsx
+++ b/app/routes/_layout.blog.tsx
@@ -1,9 +1,15 @@
-import { Link, useLoaderData } from 'react-router'
+import { Link, useLoaderData, useNavigation } from 'react-router'
 import { type MetaFunction, type LoaderFunctionArgs } from 'react-router'
+import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
+import { Skeleton } from '#app/components/ui/skeleton.tsx'
+import { getUserId } from '#app/utils/auth.server.ts'
 import { getBlogMdxListItems } from '#app/utils/blog/mdx.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
 import { getDomainUrl } from '#app/utils/misc.tsx'
+import { userHasRole } from '#app/utils/user.ts'
 
-const description = 'Articles about web development, software engineering, and more.'
+const description =
+	'Articles about web development, software engineering, and more.'
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
 	const canonicalUrl = data?.canonicalUrl
@@ -22,18 +28,65 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 }
 
 export async function loader({ request }: LoaderFunctionArgs) {
-	const posts = await getBlogMdxListItems({})
+	const url = new URL(request.url)
+	const wantsDraft = url.searchParams.get('draft') === 'true'
+
+	let showDrafts = false
+	if (wantsDraft) {
+		const userId = await getUserId(request)
+		if (userId) {
+			const user = await prisma.user.findUnique({
+				where: { id: userId },
+				select: { roles: { select: { name: true } } },
+			})
+			showDrafts = userHasRole(user, 'admin')
+		}
+	}
+
+	const posts = await getBlogMdxListItems({ showDrafts })
 	const canonicalUrl = `${getDomainUrl(request)}/blog`
-	return { posts, canonicalUrl }
+	return { posts, canonicalUrl, showDrafts }
+}
+
+function BlogListSkeleton() {
+	return (
+		<ul
+			className="flex flex-col gap-8"
+			aria-busy="true"
+			aria-label="Loading posts"
+		>
+			{Array.from({ length: 3 }).map((_, i) => (
+				<li key={i}>
+					<Skeleton className="mb-2 h-6 w-2/3" />
+					<Skeleton className="mb-2 h-4 w-1/4" />
+					<Skeleton className="h-4 w-full" />
+				</li>
+			))}
+		</ul>
+	)
 }
 
 export default function BlogIndex() {
-	const { posts } = useLoaderData<typeof loader>()
+	const { posts, showDrafts } = useLoaderData<typeof loader>()
+	const navigation = useNavigation()
+
+	const isNavigatingToPost =
+		navigation.state === 'loading' &&
+		navigation.location.pathname.startsWith('/blog/')
 
 	return (
-		<main className="container py-12">
-			<h2 className="text-h2 mb-12">Blog</h2>
-			{posts.length === 0 ? (
+		<main className="container py-12 sm:py-16">
+			<h2 className="text-h2 mb-8 sm:mb-12">Blog</h2>
+
+			{showDrafts ? (
+				<p className="mb-6 rounded border border-yellow-500 bg-yellow-50 px-4 py-2 text-sm text-yellow-800 dark:bg-yellow-950/30 dark:text-yellow-200">
+					Draft preview enabled
+				</p>
+			) : null}
+
+			{isNavigatingToPost ? (
+				<BlogListSkeleton />
+			) : posts.length === 0 ? (
 				<p className="text-muted-foreground">No posts yet.</p>
 			) : (
 				<ul className="flex flex-col gap-8">
@@ -42,18 +95,24 @@ export default function BlogIndex() {
 							<Link
 								to={`/blog/${post.slug}`}
 								className="group block"
+								prefetch="intent"
 							>
-								<h3 className="text-xl font-bold group-hover:underline">
-									{post.frontmatter.title}
-								</h3>
+								<div className="flex items-center gap-2">
+									<h3 className="text-xl font-bold group-hover:underline">
+										{post.frontmatter.title}
+									</h3>
+									{post.frontmatter.draft ? (
+										<span className="rounded bg-yellow-100 px-1.5 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200">
+											Draft
+										</span>
+									) : null}
+								</div>
 								<p className="text-muted-foreground mt-1 text-sm">
 									{post.dateDisplay}
 									{post.readTime ? ` · ${post.readTime.text}` : null}
 								</p>
 								{post.frontmatter.description ? (
-									<p className="mt-2">
-										{post.frontmatter.description}
-									</p>
+									<p className="mt-2">{post.frontmatter.description}</p>
 								) : null}
 							</Link>
 						</li>
@@ -61,5 +120,22 @@ export default function BlogIndex() {
 				</ul>
 			)}
 		</main>
+	)
+}
+
+export function ErrorBoundary() {
+	return (
+		<GeneralErrorBoundary
+			statusHandlers={{
+				404: () => (
+					<div className="text-center">
+						<p className="text-h2 mb-4">Blog not found</p>
+						<Link to="/" className="underline">
+							Go home
+						</Link>
+					</div>
+				),
+			}}
+		/>
 	)
 }

--- a/app/routes/_layout.blog_.$slug.tsx
+++ b/app/routes/_layout.blog_.$slug.tsx
@@ -37,9 +37,7 @@ export const meta: MetaFunction<typeof loader> = ({ data: loaderData }) => {
 		{ name: 'twitter:card', content: 'summary' },
 		{ name: 'twitter:title', content: page.frontmatter.title },
 		{ name: 'twitter:description', content: description },
-		...(isAdminDraftPreview
-			? [{ name: 'robots', content: 'noindex' }]
-			: []),
+		...(isAdminDraftPreview ? [{ name: 'robots', content: 'noindex' }] : []),
 	]
 }
 
@@ -56,16 +54,13 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 		if (userId) {
 			const user = await prisma.user.findUnique({
 				where: { id: userId },
-				select: { roles: { select: { name: true } } },
+				include: { roles: { select: { name: true, permissions: true } } },
 			})
 			isAdminDraftPreview = userHasRole(user, 'admin')
 		}
 	}
 
-	const page = await getMdxPage(
-		{ slug },
-		{ forceFresh: isAdminDraftPreview },
-	)
+	const page = await getMdxPage({ slug }, { forceFresh: isAdminDraftPreview })
 	if (!page) throw data('Not found', { status: 404 })
 
 	if (page.frontmatter.draft && !isAdminDraftPreview) {

--- a/app/routes/_layout.blog_.$slug.tsx
+++ b/app/routes/_layout.blog_.$slug.tsx
@@ -1,5 +1,11 @@
-import { data, Link, useLoaderData, useNavigation } from 'react-router'
-import { type MetaFunction, type LoaderFunctionArgs } from 'react-router'
+import {
+	data,
+	Link,
+	useLoaderData,
+	useNavigation,
+	type MetaFunction,
+	type LoaderFunctionArgs,
+} from 'react-router'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
 import { Skeleton } from '#app/components/ui/skeleton.tsx'
 import { getUserId } from '#app/utils/auth.server.ts'

--- a/app/utils/blog/mdx.server.ts
+++ b/app/utils/blog/mdx.server.ts
@@ -96,10 +96,10 @@ export async function getMdxDirList(options?: CachifiedOptions) {
 }
 
 export async function getBlogMdxListItems(
-	options: CachifiedOptions,
+	options: CachifiedOptions & { showDrafts?: boolean },
 ): Promise<Array<MdxListItem>> {
-	const { forceFresh, ttl = defaultTTL, timings } = options
-	const key = 'blog:mdx-list-items'
+	const { forceFresh, ttl = defaultTTL, timings, showDrafts = false } = options
+	const key = showDrafts ? 'blog:mdx-list-items:drafts' : 'blog:mdx-list-items'
 	return cachified({
 		cache,
 		timings,
@@ -109,7 +109,11 @@ export async function getBlogMdxListItems(
 		key,
 		getFreshValue: async () => {
 			let pages = await getMdxPagesInDirectory(options).then((allPosts) =>
-				allPosts.filter((p) => !p.frontmatter.draft && !p.frontmatter.unlisted),
+				allPosts.filter(
+					(p) =>
+						!p.frontmatter.unlisted &&
+						(showDrafts || !p.frontmatter.draft),
+				),
 			)
 
 			pages = pages.sort((a, z) => {

--- a/content/blog/hello-world/index.mdx
+++ b/content/blog/hello-world/index.mdx
@@ -1,13 +1,60 @@
 ---
 title: Hello World
-description: My first blog post
+description: My first blog post — exploring the blog setup, MDX features, and what's coming next.
 date: '2026-02-21'
+categories: ['meta']
 ---
 
-# Hello World
+Welcome to my blog. This post doubles as a test of the MDX pipeline and a quick
+intro to the features available for future writing.
 
-Welcome to my blog! This is a test post to verify the blog routes work correctly.
+## Code highlighting
+
+TypeScript with Shiki dual-theme (light and dark):
+
+```ts
+function greet(name: string): string {
+  return `Hello, ${name}!`
+}
+```
+
+A JSX example:
+
+```tsx
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border p-4">
+      <h3>{title}</h3>
+      {children}
+    </div>
+  )
+}
+```
+
+## GitHub Flavored Markdown
+
+Tables, strikethrough, and task lists all work out of the box.
+
+| Feature            | Status |
+| ------------------ | ------ |
+| Syntax highlighting | Done  |
+| oEmbed embeds      | Done   |
+| Draft preview      | Done   |
+
+- [x] Write first post
+- [ ] Write second post
+- [ ] ~~Procrastinate~~ — never!
+
+## Callouts
+
+<Callout variant="info">
+  This is an info callout rendered via a custom MDX component.
+</Callout>
+
+<Callout variant="warning">
+  Be careful — this is a warning callout.
+</Callout>
 
 ## What's next?
 
-Stay tuned for more content.
+More posts on web development and software engineering are coming. Stay tuned.


### PR DESCRIPTION
## Summary
- Enriched hello-world post with Shiki code blocks, GFM tables, and Callout components
- Added `showDrafts` option to `getBlogMdxListItems` with separate cache key
- Blog listing: loading skeleton via `useNavigation`, admin draft preview (`?draft=true`), error boundary
- Blog post: loading skeleton, responsive prose (`prose-sm sm:prose-base lg:prose-lg`), back link, draft banner with `noindex`, custom 404 boundary
- Non-admins get 404 on draft posts

## Test plan
- [ ] Navigate /blog — verify post listing renders
- [ ] Click into /blog/hello-world — verify skeleton appears during navigation, prose is responsive
- [ ] Visit /blog/nonexistent — verify custom 404 error boundary
- [ ] Login as admin, visit /blog?draft=true — verify draft banner + draft badge on posts
- [ ] Login as admin, visit /blog/draft-slug?draft=true — verify draft preview banner + noindex meta
- [ ] Resize viewport — verify responsive layout mobile/tablet/desktop
- [ ] Tab through blog listing — verify keyboard navigation

Resolves #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)