### PR TITLE
feat(blog): Phase 2 — Blog listing page

### DIFF
--- a/app/routes/_marketing/blog._index.tsx
+++ b/app/routes/_marketing/blog._index.tsx
@@ -1,0 +1,44 @@
+import { Link } from 'react-router'
+import { getPostListings } from '#app/utils/blog/mdx.server.ts'
+import { type Route } from './+types/blog._index.js'
+
+export async function loader() {
+	const posts = await getPostListings()
+	return { posts }
+}
+
+export default function BlogIndexRoute({ loaderData }: Route.ComponentProps) {
+	const { posts } = loaderData
+
+	return (
+		<main className="container mx-auto max-w-3xl px-4 py-12">
+			<h1 className="text-h2 mb-8">Blog</h1>
+			{posts.length === 0 ? (
+				<p className="text-muted-foreground">No posts yet.</p>
+			) : (
+				<ul className="space-y-8">
+					{posts.map((post) => (
+						<li key={post.slug}>
+							<Link to={`/blog/${post.slug}`} className="group block">
+								<h2 className="text-h4 group-hover:underline">
+									{post.title}
+								</h2>
+								<p className="text-muted-foreground mt-1 text-sm">
+									{new Date(post.date).toLocaleDateString('en-US', {
+										year: 'numeric',
+										month: 'long',
+										day: 'numeric',
+										timeZone: 'UTC',
+									})}
+								</p>
+								<p className="text-muted-foreground mt-2">
+									{post.description}
+								</p>
+							</Link>
+						</li>
+					))}
+				</ul>
+			)}
+		</main>
+	)
+}

--- a/app/utils/blog/github.server.ts
+++ b/app/utils/blog/github.server.ts
@@ -6,6 +6,21 @@ const CONTENT_PATH = 'content/blog'
 
 const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN })
 
+export async function getPostSlugs(): Promise<string[]> {
+	const { data } = await octokit.repos.getContent({
+		owner: REPO_OWNER,
+		repo: REPO_NAME,
+		path: CONTENT_PATH,
+		ref: 'master',
+	})
+
+	if (!Array.isArray(data)) {
+		throw new Error(`Expected a directory at ${CONTENT_PATH}, got a file`)
+	}
+
+	return data.filter((item) => item.type === 'dir').map((item) => item.name)
+}
+
 export async function getPostContent(slug: string): Promise<string> {
 	const filePath = `${CONTENT_PATH}/${slug}/index.mdx`
 

--- a/app/utils/blog/mdx.server.ts
+++ b/app/utils/blog/mdx.server.ts
@@ -1,10 +1,57 @@
 import { bundleMDX } from 'mdx-bundler'
 import readingTime from 'reading-time'
 import remarkGfm from 'remark-gfm'
+import { getPostContent, getPostSlugs } from './github.server.ts'
 import {
 	BlogPostFrontmatterSchema,
 	type BlogPostFrontmatter,
 } from './blog.schema.ts'
+
+export type BlogPostListing = {
+	slug: string
+	title: string
+	description: string
+	date: string
+}
+
+export async function getPostListings(): Promise<BlogPostListing[]> {
+	const slugs = await getPostSlugs()
+
+	const posts = await Promise.all(
+		slugs.map(async (slug) => {
+			try {
+				const source = await getPostContent(slug)
+				const { frontmatter: rawFrontmatter } = await bundleMDX({
+					source,
+					mdxOptions(options) {
+						options.remarkPlugins = [
+							...(options.remarkPlugins ?? []),
+							remarkGfm,
+						]
+						return options
+					},
+				})
+
+				const result = BlogPostFrontmatterSchema.safeParse(rawFrontmatter)
+				if (!result.success) return null
+				if (!result.data.published) return null
+
+				return {
+					slug,
+					title: result.data.title,
+					description: result.data.description,
+					date: result.data.date.toISOString(),
+				}
+			} catch {
+				return null
+			}
+		}),
+	)
+
+	return posts
+		.filter((post): post is BlogPostListing => post !== null)
+		.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+}
 
 export type CompiledBlogPost = {
 	code: string

--- a/app/utils/blog/mdx.server.ts
+++ b/app/utils/blog/mdx.server.ts
@@ -1,11 +1,11 @@
 import { bundleMDX } from 'mdx-bundler'
 import readingTime from 'reading-time'
 import remarkGfm from 'remark-gfm'
-import { getPostContent, getPostSlugs } from './github.server.ts'
 import {
 	BlogPostFrontmatterSchema,
 	type BlogPostFrontmatter,
 } from './blog.schema.ts'
+import { getPostContent, getPostSlugs } from './github.server.ts'
 
 export type BlogPostListing = {
 	slug: string
@@ -42,7 +42,11 @@ export async function getPostListings(): Promise<BlogPostListing[]> {
 					description: result.data.description,
 					date: result.data.date.toISOString(),
 				}
-			} catch {
+			} catch (error) {
+				console.error(
+					`Failed to process blog post listing for slug "${slug}"`,
+					error,
+				)
 				return null
 			}
 		}),

--- a/tests/e2e/blog.test.ts
+++ b/tests/e2e/blog.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '#tests/playwright-utils.ts'
+
+test('Blog listing page displays published posts', async ({
+	page,
+	navigate,
+}) => {
+	await navigate('/blog')
+
+	await expect(page.getByRole('heading', { level: 1 })).toHaveText('Blog')
+
+	const postLink = page.getByRole('link', {
+		name: /Hello World: My First Blog Post/,
+	})
+	await expect(postLink).toBeVisible()
+
+	await expect(postLink).toContainText('April 5, 2026')
+	await expect(postLink).toContainText('Welcome to my blog! In this first post')
+
+	await postLink.click()
+	await expect(page).toHaveURL(/\/blog\/hello-world$/)
+	await expect(
+		page.getByRole('heading', { name: /Hello World: My First Blog Post/ }),
+	).toBeVisible()
+})

--- a/tests/mocks/github.ts
+++ b/tests/mocks/github.ts
@@ -197,6 +197,20 @@ export const handlers: Array<HttpHandler> = [
 				return new Response('Not Found', { status: 404 })
 			}
 
+			const stat = await fsExtra.stat(filePath)
+			if (stat.isDirectory()) {
+				const entries = await fsExtra.readdir(filePath, {
+					withFileTypes: true,
+				})
+				return json(
+					entries.map((entry) => ({
+						type: entry.isDirectory() ? 'dir' : 'file',
+						name: entry.name,
+						path: `${contentPath}/${entry.name}`,
+					})),
+				)
+			}
+
 			const content = await fsExtra.readFile(filePath, 'utf-8')
 			return json({
 				type: 'file',


### PR DESCRIPTION
## Summary
- Adds `/blog` route that lists all published blog posts sorted newest-first
- Each entry displays title, description, and formatted date, linking to `/blog/<slug>`
- Posts with `published: false` or invalid frontmatter are excluded
- Updates MSW mock to support GitHub Contents API directory listing

Closes #35

## Test plan
- [x] E2E test: `/blog` loads, displays post titles/descriptions/dates, and links navigate to individual posts
- [x] Existing unit tests (9) and blog post route still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a blog index page showing published posts with title, publish date, and description, sorted newest-first; shows "No posts yet" when empty and links to each full article.
* **Tests**
  * Added an end-to-end test covering the blog index, post link, and post page navigation.
* **Chores**
  * Improved backend/content handling and test mocks to support directory-based post listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->