### PR TITLE
feat(blog): Phase 5 — Caching and compilation queue

### DIFF
--- a/app/routes/_marketing/blog.$slug.tsx
+++ b/app/routes/_marketing/blog.$slug.tsx
@@ -2,19 +2,17 @@ import { getMDXComponent } from 'mdx-bundler/client'
 import { Img } from 'openimg/react'
 import { useMemo } from 'react'
 import { data } from 'react-router'
-import { getPostContent } from '#app/utils/blog/github.server.ts'
-import { compileMdxPost, getBlogImageSrc } from '#app/utils/blog/mdx.server.ts'
+import { getCachedCompiledPost } from '#app/utils/blog/cache.server.ts'
+import { getBlogImageSrc } from '#app/utils/blog/mdx.server.ts'
 import { type Route } from './+types/blog.$slug.js'
 
 export async function loader({ params }: Route.LoaderArgs) {
 	const { slug } = params
 
-	const source = await getPostContent(slug).catch((error) => {
+	const post = await getCachedCompiledPost(slug).catch((error) => {
 		console.error(error)
 		throw data(null, { status: 404 })
 	})
-
-	const post = await compileMdxPost(slug, source)
 
 	return {
 		code: post.code,

--- a/app/routes/_marketing/blog._index.tsx
+++ b/app/routes/_marketing/blog._index.tsx
@@ -1,10 +1,10 @@
 import { Img } from 'openimg/react'
 import { Link } from 'react-router'
-import { getPostListings } from '#app/utils/blog/mdx.server.ts'
+import { getCachedPostListings } from '#app/utils/blog/cache.server.ts'
 import { type Route } from './+types/blog._index.js'
 
 export async function loader() {
-	const posts = await getPostListings()
+	const posts = await getCachedPostListings()
 	return { posts }
 }
 

--- a/app/utils/blog/cache.server.test.ts
+++ b/app/utils/blog/cache.server.test.ts
@@ -63,7 +63,7 @@ describe('compilationQueue', () => {
 		let maxRunning = 0
 
 		const task = () =>
-			compilationQueue.run(async () => {
+			compilationQueue(async () => {
 				running++
 				maxRunning = Math.max(maxRunning, running)
 				await new Promise((r) => setTimeout(r, 50))
@@ -80,7 +80,7 @@ describe('compilationQueue', () => {
 		const results: number[] = []
 
 		const tasks = Array.from({ length: 5 }, (_, i) =>
-			compilationQueue.run(async () => {
+			compilationQueue(async () => {
 				await new Promise((r) => setTimeout(r, 10))
 				results.push(i)
 				return i

--- a/app/utils/blog/cache.server.test.ts
+++ b/app/utils/blog/cache.server.test.ts
@@ -31,25 +31,31 @@ describe('getCachedCompiledPost', { timeout: 15_000 }, () => {
 	})
 
 	test('returns cached result on second call', async () => {
+		// arrange
 		blogLruCache.delete('blog:post:cached-test')
 		mockedGetPostContent.mockResolvedValue(validSource)
 
+		// act
 		const first = await getCachedCompiledPost('cached-test')
 		const second = await getCachedCompiledPost('cached-test')
 
+		// assert
 		expect(first.frontmatter.title).toBe('Cached Post')
 		expect(second).toBe(first) // same reference = served from cache
 		expect(mockedGetPostContent).toHaveBeenCalledTimes(1)
 	})
 
 	test('recompiles after cache entry is deleted', async () => {
+		// arrange
 		blogLruCache.delete('blog:post:recompile-test')
 		mockedGetPostContent.mockResolvedValue(validSource)
 
+		// act
 		const first = await getCachedCompiledPost('recompile-test')
 		blogLruCache.delete('blog:post:recompile-test')
 		const second = await getCachedCompiledPost('recompile-test')
 
+		// assert
 		expect(first.frontmatter.title).toBe('Cached Post')
 		expect(second.frontmatter.title).toBe('Cached Post')
 		expect(second).not.toBe(first) // different reference = recompiled
@@ -59,9 +65,9 @@ describe('getCachedCompiledPost', { timeout: 15_000 }, () => {
 
 describe('compilationQueue', () => {
 	test('limits concurrent executions to 2', async () => {
+		// arrange
 		let running = 0
 		let maxRunning = 0
-
 		const task = () =>
 			compilationQueue(async () => {
 				running++
@@ -71,14 +77,16 @@ describe('compilationQueue', () => {
 				return maxRunning
 			})
 
+		// act
 		await Promise.all([task(), task(), task(), task()])
 
+		// assert
 		expect(maxRunning).toBeLessThanOrEqual(2)
 	})
 
 	test('all queued tasks complete', async () => {
+		// arrange
 		const results: number[] = []
-
 		const tasks = Array.from({ length: 5 }, (_, i) =>
 			compilationQueue(async () => {
 				await new Promise((r) => setTimeout(r, 10))
@@ -87,8 +95,10 @@ describe('compilationQueue', () => {
 			}),
 		)
 
+		// act
 		const returned = await Promise.all(tasks)
 
+		// assert
 		expect(returned).toEqual([0, 1, 2, 3, 4])
 		expect(results).toHaveLength(5)
 	})

--- a/app/utils/blog/cache.server.test.ts
+++ b/app/utils/blog/cache.server.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+	blogLruCache,
+	compilationQueue,
+	getCachedCompiledPost,
+} from './cache.server.ts'
+import { getPostContent } from './github.server.ts'
+
+vi.mock('./github.server.ts', () => ({
+	getPostContent: vi.fn(),
+	getPostSlugs: vi.fn(),
+	REPO_OWNER: 'M-Kolacz',
+	REPO_NAME: 'michalkolacz.com',
+}))
+
+const mockedGetPostContent = vi.mocked(getPostContent)
+
+const validSource = `---
+title: "Cached Post"
+description: "A cached test post"
+date: "2026-04-05"
+published: true
+---
+
+Hello cached world.
+`
+
+describe('getCachedCompiledPost', { timeout: 15_000 }, () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	test('returns cached result on second call', async () => {
+		blogLruCache.delete('blog:post:cached-test')
+		mockedGetPostContent.mockResolvedValue(validSource)
+
+		const first = await getCachedCompiledPost('cached-test')
+		const second = await getCachedCompiledPost('cached-test')
+
+		expect(first.frontmatter.title).toBe('Cached Post')
+		expect(second).toBe(first) // same reference = served from cache
+		expect(mockedGetPostContent).toHaveBeenCalledTimes(1)
+	})
+
+	test('recompiles after cache entry is deleted', async () => {
+		blogLruCache.delete('blog:post:recompile-test')
+		mockedGetPostContent.mockResolvedValue(validSource)
+
+		const first = await getCachedCompiledPost('recompile-test')
+		blogLruCache.delete('blog:post:recompile-test')
+		const second = await getCachedCompiledPost('recompile-test')
+
+		expect(first.frontmatter.title).toBe('Cached Post')
+		expect(second.frontmatter.title).toBe('Cached Post')
+		expect(second).not.toBe(first) // different reference = recompiled
+		expect(mockedGetPostContent).toHaveBeenCalledTimes(2)
+	})
+})
+
+describe('compilationQueue', () => {
+	test('limits concurrent executions to 2', async () => {
+		let running = 0
+		let maxRunning = 0
+
+		const task = () =>
+			compilationQueue.run(async () => {
+				running++
+				maxRunning = Math.max(maxRunning, running)
+				await new Promise((r) => setTimeout(r, 50))
+				running--
+				return maxRunning
+			})
+
+		await Promise.all([task(), task(), task(), task()])
+
+		expect(maxRunning).toBeLessThanOrEqual(2)
+	})
+
+	test('all queued tasks complete', async () => {
+		const results: number[] = []
+
+		const tasks = Array.from({ length: 5 }, (_, i) =>
+			compilationQueue.run(async () => {
+				await new Promise((r) => setTimeout(r, 10))
+				results.push(i)
+				return i
+			}),
+		)
+
+		const returned = await Promise.all(tasks)
+
+		expect(returned).toEqual([0, 1, 2, 3, 4])
+		expect(results).toHaveLength(5)
+	})
+})

--- a/app/utils/blog/cache.server.ts
+++ b/app/utils/blog/cache.server.ts
@@ -34,32 +34,27 @@ export const blogLruCache = {
 } satisfies Cache
 
 // Compilation queue — limits concurrent MDX compilations to prevent memory spikes
-class CompilationQueue {
-	#concurrency: number
-	#running = 0
-	#queue: Array<() => void> = []
+function createCompilationQueue(concurrency: number) {
+	let running = 0
+	const queue: Array<() => void> = []
 
-	constructor(concurrency: number) {
-		this.#concurrency = concurrency
-	}
-
-	async run<T>(fn: () => Promise<T>): Promise<T> {
-		if (this.#running >= this.#concurrency) {
-			await new Promise<void>((resolve) => this.#queue.push(resolve))
+	return async function run<T>(fn: () => Promise<T>): Promise<T> {
+		if (running >= concurrency) {
+			await new Promise<void>((resolve) => queue.push(resolve))
 		}
-		this.#running++
+		running++
 		try {
 			return await fn()
 		} finally {
-			this.#running--
-			this.#queue.shift()?.()
+			running--
+			queue.shift()?.()
 		}
 	}
 }
 
 export const compilationQueue = remember(
 	'blog-compilation-queue',
-	() => new CompilationQueue(2),
+	() => createCompilationQueue(2),
 )
 
 const POST_TTL = 1000 * 60 * 60 // 1 hour
@@ -77,7 +72,7 @@ export async function getCachedCompiledPost(
 		swr: POST_SWR,
 		async getFreshValue() {
 			const source = await getPostContent(slug)
-			return compilationQueue.run(() => compileMdxPost(slug, source))
+			return compilationQueue(() => compileMdxPost(slug, source))
 		},
 	})
 }

--- a/app/utils/blog/cache.server.ts
+++ b/app/utils/blog/cache.server.ts
@@ -1,0 +1,95 @@
+import {
+	cachified,
+	type CacheEntry,
+	totalTtl,
+	type Cache,
+} from '@epic-web/cachified'
+import { remember } from '@epic-web/remember'
+import { LRUCache } from 'lru-cache'
+import { getPostContent } from './github.server.ts'
+import {
+	compileMdxPost,
+	getPostListings,
+	type BlogPostListing,
+	type CompiledBlogPost,
+} from './mdx.server.ts'
+
+const blogCache = remember(
+	'blog-lru-cache',
+	() => new LRUCache<string, CacheEntry<unknown>>({ max: 500 }),
+)
+
+export const blogLruCache = {
+	name: 'blog-memory-cache',
+	set: (key, value) => {
+		const ttl = totalTtl(value?.metadata)
+		blogCache.set(key, value, {
+			ttl: ttl === Infinity ? undefined : ttl,
+			start: value?.metadata?.createdTime,
+		})
+		return value
+	},
+	get: (key) => blogCache.get(key),
+	delete: (key) => blogCache.delete(key),
+} satisfies Cache
+
+// Compilation queue — limits concurrent MDX compilations to prevent memory spikes
+class CompilationQueue {
+	#concurrency: number
+	#running = 0
+	#queue: Array<() => void> = []
+
+	constructor(concurrency: number) {
+		this.#concurrency = concurrency
+	}
+
+	async run<T>(fn: () => Promise<T>): Promise<T> {
+		if (this.#running >= this.#concurrency) {
+			await new Promise<void>((resolve) => this.#queue.push(resolve))
+		}
+		this.#running++
+		try {
+			return await fn()
+		} finally {
+			this.#running--
+			this.#queue.shift()?.()
+		}
+	}
+}
+
+export const compilationQueue = remember(
+	'blog-compilation-queue',
+	() => new CompilationQueue(2),
+)
+
+const POST_TTL = 1000 * 60 * 60 // 1 hour
+const POST_SWR = 1000 * 60 * 60 * 24 // 1 day stale-while-revalidate
+const LISTING_TTL = 1000 * 60 * 5 // 5 minutes
+const LISTING_SWR = 1000 * 60 * 60 // 1 hour stale-while-revalidate
+
+export async function getCachedCompiledPost(
+	slug: string,
+): Promise<CompiledBlogPost> {
+	return cachified({
+		key: `blog:post:${slug}`,
+		cache: blogLruCache,
+		ttl: POST_TTL,
+		swr: POST_SWR,
+		async getFreshValue() {
+			const source = await getPostContent(slug)
+			return compilationQueue.run(() => compileMdxPost(slug, source))
+		},
+	})
+}
+
+export async function getCachedPostListings(): Promise<BlogPostListing[]> {
+	return cachified({
+		key: 'blog:listings',
+		cache: blogLruCache,
+		ttl: LISTING_TTL,
+		swr: LISTING_SWR,
+		async getFreshValue() {
+			return getPostListings()
+		},
+	})
+}

--- a/app/utils/blog/cache.server.ts
+++ b/app/utils/blog/cache.server.ts
@@ -47,14 +47,14 @@ function createCompilationQueue(concurrency: number) {
 			return await fn()
 		} finally {
 			running--
-			queue.shift()?.()
+			const nextInQueue = queue.shift()
+			nextInQueue?.()
 		}
 	}
 }
 
-export const compilationQueue = remember(
-	'blog-compilation-queue',
-	() => createCompilationQueue(2),
+export const compilationQueue = remember('blog-compilation-queue', () =>
+	createCompilationQueue(2),
 )
 
 const POST_TTL = 1000 * 60 * 60 // 1 hour


### PR DESCRIPTION
## Summary
- Added LRU cache (`@epic-web/cachified` + `lru-cache`) for compiled MDX output — repeated requests served from memory
- Implemented concurrency-limited compilation queue (max 2 concurrent compilations) to prevent memory spikes
- Post cache TTL: 1 hour with 1 day stale-while-revalidate; listing cache TTL: 5 minutes with 1 hour SWR
- New posts pushed to GitHub appear without redeployment after cache expiry
- Route loaders updated to use cached variants (`getCachedCompiledPost`, `getCachedPostListings`)

Closes #38

## Test plan
- [x] Unit test: cache returns previously compiled result on second call (same reference)
- [x] Unit test: expired/deleted cache triggers recompilation (different reference)
- [x] Unit test: compilation queue limits concurrency to 2
- [x] Unit test: all queued tasks complete successfully
- [x] Existing MDX compilation tests still pass (7 tests)
- [x] TypeScript type check passes
- [ ] E2E: verify `/blog` and `/blog/<slug>` load correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests verifying blog post caching semantics and concurrent compilation behavior.

* **Refactor**
  * Blog post routes now serve cached, precompiled content for faster page loads.
  * Introduced a server-side in-memory cache and a concurrency-limited compilation runner to improve performance and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->