### PR TITLE
feat(blog): Phase 6 — RSS feed and Open Graph meta tags

### DIFF
--- a/app/routes/_marketing/blog.$slug.tsx
+++ b/app/routes/_marketing/blog.$slug.tsx
@@ -6,6 +6,29 @@ import { getCachedCompiledPost } from '#app/utils/blog/cache.server.ts'
 import { getBlogImageSrc } from '#app/utils/blog/mdx.server.ts'
 import { type Route } from './+types/blog.$slug.js'
 
+export const meta: Route.MetaFunction = ({ data, matches }) => {
+	const rootData = matches[0]?.data as
+		| { requestInfo: { origin: string } }
+		| undefined
+	const origin = rootData?.requestInfo.origin ?? ''
+
+	if (!data) {
+		return [{ title: 'Post Not Found' }]
+	}
+
+	const { frontmatter, bannerImage } = data
+	const ogImage = bannerImage ? `${origin}${bannerImage}` : null
+
+	return [
+		{ title: `${frontmatter.title} | Michal Kolacz` },
+		{ name: 'description', content: frontmatter.description },
+		{ property: 'og:title', content: frontmatter.title },
+		{ property: 'og:description', content: frontmatter.description },
+		{ property: 'og:type', content: 'article' },
+		...(ogImage ? [{ property: 'og:image', content: ogImage }] : []),
+	]
+}
+
 export async function loader({ params }: Route.LoaderArgs) {
 	const { slug } = params
 

--- a/app/routes/_marketing/blog._index.tsx
+++ b/app/routes/_marketing/blog._index.tsx
@@ -3,6 +3,22 @@ import { Link } from 'react-router'
 import { getCachedPostListings } from '#app/utils/blog/cache.server.ts'
 import { type Route } from './+types/blog._index.js'
 
+export const meta: Route.MetaFunction = () => {
+	return [
+		{ title: 'Blog | Michal Kolacz' },
+		{
+			name: 'description',
+			content: 'Blog posts by Michal Kolacz about software engineering.',
+		},
+		{ property: 'og:title', content: 'Blog | Michal Kolacz' },
+		{
+			property: 'og:description',
+			content: 'Blog posts by Michal Kolacz about software engineering.',
+		},
+		{ property: 'og:type', content: 'website' },
+	]
+}
+
 export async function loader() {
 	const posts = await getCachedPostListings()
 	return { posts }

--- a/app/routes/_marketing/blog.rss[.]xml.ts
+++ b/app/routes/_marketing/blog.rss[.]xml.ts
@@ -1,0 +1,48 @@
+import { getCachedPostListings } from '#app/utils/blog/cache.server.ts'
+import { getDomainUrl } from '#app/utils/misc.tsx'
+import { type Route } from './+types/blog.rss[.]xml.ts'
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const posts = await getCachedPostListings()
+	const domainUrl = getDomainUrl(request)
+	const blogUrl = `${domainUrl}/blog`
+	const feedUrl = `${domainUrl}/blog/rss.xml`
+
+	const rss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Michal Kolacz Blog</title>
+    <description>Blog posts by Michal Kolacz</description>
+    <link>${blogUrl}</link>
+    <atom:link href="${feedUrl}" rel="self" type="application/rss+xml"/>
+    <language>en</language>${posts
+			.map(
+				(post) => `
+    <item>
+      <title>${escapeXml(post.title)}</title>
+      <description>${escapeXml(post.description)}</description>
+      <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+      <link>${domainUrl}/blog/${post.slug}</link>
+      <guid isPermaLink="true">${domainUrl}/blog/${post.slug}</guid>
+    </item>`,
+			)
+			.join('')}
+  </channel>
+</rss>`
+
+	return new Response(rss, {
+		headers: {
+			'Content-Type': 'application/rss+xml; charset=utf-8',
+			'Cache-Control': `public, max-age=${60 * 5}`,
+		},
+	})
+}
+
+function escapeXml(str: string): string {
+	return str
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&apos;')
+}

--- a/tests/e2e/blog.test.ts
+++ b/tests/e2e/blog.test.ts
@@ -1,5 +1,56 @@
 import { expect, test } from '#tests/playwright-utils.ts'
 
+test('RSS feed returns valid XML with expected entries', async ({
+	page,
+	baseURL,
+}) => {
+	const response = await page.request.get(`${baseURL}blog/rss.xml`)
+
+	expect(response.status()).toBe(200)
+	expect(response.headers()['content-type']).toContain('application/rss+xml')
+
+	const body = await response.text()
+	expect(body).toContain('<?xml version="1.0"')
+	expect(body).toContain('<rss version="2.0"')
+	expect(body).toContain('<title>Michal Kolacz Blog</title>')
+	expect(body).toContain('<item>')
+	expect(body).toContain('Hello World: My First Blog Post')
+	expect(body).toContain('/blog/hello-world</link>')
+})
+
+test('Blog post page has correct OG meta tags', async ({ page, navigate }) => {
+	await navigate('/blog/:slug', { slug: 'hello-world' })
+
+	await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+		'content',
+		'Hello World: My First Blog Post',
+	)
+	await expect(
+		page.locator('meta[property="og:description"]'),
+	).toHaveAttribute('content', /Welcome to my blog/)
+	await expect(page.locator('meta[property="og:type"]')).toHaveAttribute(
+		'content',
+		'article',
+	)
+	await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+		'content',
+		/\/resources\/images/,
+	)
+})
+
+test('Blog listing page has OG meta tags', async ({ page, navigate }) => {
+	await navigate('/blog')
+
+	await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+		'content',
+		'Blog | Michal Kolacz',
+	)
+	await expect(page.locator('meta[property="og:type"]')).toHaveAttribute(
+		'content',
+		'website',
+	)
+})
+
 test('Blog listing page displays published posts', async ({
 	page,
 	navigate,


### PR DESCRIPTION
## Summary
- Add RSS 2.0 feed route at `/blog/rss.xml` with all published posts, proper XML escaping, and 5-minute cache control
- Add Open Graph meta tags (`og:title`, `og:description`, `og:type`, `og:image`) to individual blog post pages
- Add generic OG meta tags (`og:title`, `og:description`, `og:type`) to the blog listing page
- Add `title` and `description` meta tags to both blog routes

Closes #39

## Test plan
- [x] E2E: `/blog/rss.xml` returns 200 with valid RSS XML containing expected entries
- [x] E2E: Blog post page has correct OG meta tags in HTML head
- [x] E2E: Blog listing page has OG meta tags in HTML head
- [x] TypeScript compiles with no errors
- [x] All 7 blog E2E tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog posts and listing pages now include SEO metadata (titles, descriptions, and Open Graph tags) to enhance search engine visibility and optimize preview content when shared on social media
  * New RSS feed endpoint enables readers to subscribe to blog updates and receive new posts automatically through RSS readers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->