### PR TITLE
feat: configure custom domain and www redirect

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,8 @@ on:
   push:
     branches:
       - master
-      - dev
   pull_request: {}
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -202,7 +202,6 @@ jobs:
         with:
           name: failed-screenshots
           path: tests/visual/__failed-snapshots__/
-
   container:
     name: 📦 Prepare Container
     runs-on: ubuntu-24.04
@@ -252,11 +251,10 @@ jobs:
   deploy:
     name: 🚀 Deploy
     runs-on: ubuntu-24.04
-    needs: [lint, typecheck, vitest, playwright, container]
+    needs: [lint, typecheck, vitest, playwright,visual-tests,container]
     environment:
-      name: Dev
+      name: Production
       url: https://michalkolacz.com/
-    # only deploy on pushes
     if: ${{ github.event_name == 'push' }}
     steps:
       - name: ⬇️ Checkout repo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
   pull_request: {}
-  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -255,7 +255,7 @@ jobs:
     needs: [lint, typecheck, vitest, playwright, container]
     environment:
       name: Dev
-      url: https://michalkolacz-com-5b79.fly.dev/
+      url: https://michalkolacz.com/
     # only deploy on pushes
     if: ${{ github.event_name == 'push' }}
     steps:

--- a/server/index.ts
+++ b/server/index.ts
@@ -41,6 +41,17 @@ app.use((req, res, next) => {
 	next()
 })
 
+// redirect www to non-www canonical domain
+app.use((req, res, next) => {
+	const host = getHost(req)
+	if (host.startsWith('www.')) {
+		const nonWwwHost = host.slice(4)
+		res.redirect(301, `https://${nonWwwHost}${req.originalUrl}`)
+		return
+	}
+	next()
+})
+
 // no ending slashes for SEO reasons
 // https://github.com/epicweb-dev/epic-stack/discussions/108
 app.get(/.*/, (req, res, next) => {


### PR DESCRIPTION
## Summary
- Update deploy workflow environment URL from `.fly.dev` to `michalkolacz.com`
- Add www → non-www 301 redirect in the Express server middleware

Closes #73

## Test plan
- [x] Verify `https://michalkolacz.com` loads with valid HTTPS
- [ ] Verify `https://www.michalkolacz.com` redirects to `https://michalkolacz.com`
- [ ] Verify `http://michalkolacz.com` redirects to HTTPS
- [x] Verify GitHub Actions deployment environment link points to the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic URL redirects: requests beginning with "www." are redirected to the canonical HTTPS domain.

* **Chores**
  * Deployment environment updated to Production with the public site URL.
  * Manual deployment trigger (workflow_dispatch) added.
  * CI deployment now depends on visual tests; removed pushes to the dev branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->