### PR TITLE
Remove staging environment from CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -222,20 +222,7 @@ jobs:
       - name: 🎈 Setup Fly
         uses: superfly/flyctl-actions/setup-flyctl@1.5
 
-      - name: 📦 Build Staging Container
-        if: ${{ github.ref == 'refs/heads/dev' }}
-        run: |
-          flyctl deploy \
-            --build-only \
-            --push \
-            --image-label ${{ github.sha }} \
-            --build-arg COMMIT_SHA=${{ github.sha }} \
-            --app ${{ steps.app_name.outputs.value }}-staging
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
       - name: 📦 Build Production Container
-        if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           flyctl deploy \
             --build-only \
@@ -272,7 +259,6 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@1.5
 
       - name: 🚀 Deploy Production
-        if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           flyctl deploy \
             --image "registry.fly.io/${{ steps.app_name.outputs.value }}:${{ github.sha }}"


### PR DESCRIPTION
## Summary

- Remove the staging container build step that deployed to `*-staging` app on `dev` branch pushes
- Remove redundant `refs/heads/master` branch conditions from production build and deploy steps (the workflow trigger already limits pushes to `master` only)

Closes #66

## Test plan

- [ ] Verify CI pipeline runs green on this PR (lint, typecheck, vitest, playwright, visual tests)
- [ ] Confirm no staging app references remain in the workflow
- [ ] Verify pushing to `master` still triggers the full pipeline through to production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Removed staging environment build step that previously deployed on the dev branch
* Simplified production deployment process by removing redundant conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->