### PR TITLE
test: expand homepage E2E test to verify full page structure

### DIFF
--- a/tests/e2e/homepage.test.ts
+++ b/tests/e2e/homepage.test.ts
@@ -9,7 +9,9 @@ test('Homepage displays correctly', async ({ page, navigate }) => {
 	await expect(page.getByAltText(t('homepage.hero.imageAlt'))).toBeVisible()
 	await expect(page.getByText(t('homepage.latestPosts.heading'))).toBeVisible()
 	await expect(page.getByRole('listitem').first()).toBeVisible()
-	await expect(page.getByText(t('homepage.latestPosts.viewAll'))).toBeVisible()
+	await expect(
+		page.getByRole('link', { name: t('homepage.latestPosts.viewAll') }),
+	).toBeVisible()
 })
 
 test('Homepage has correct meta tags', async ({ page, navigate }) => {

--- a/tests/e2e/homepage.test.ts
+++ b/tests/e2e/homepage.test.ts
@@ -5,6 +5,11 @@ test('Homepage displays correctly', async ({ page, navigate }) => {
 	await navigate('/')
 
 	await expect(page.getByText(t('homepage.hero.heading'))).toBeVisible()
+	await expect(page.getByText(t('homepage.hero.subheading'))).toBeVisible()
+	await expect(page.getByAltText(t('homepage.hero.imageAlt'))).toBeVisible()
+	await expect(page.getByText(t('homepage.latestPosts.heading'))).toBeVisible()
+	await expect(page.getByRole('listitem').first()).toBeVisible()
+	await expect(page.getByText(t('homepage.latestPosts.viewAll'))).toBeVisible()
 })
 
 test('Homepage has correct meta tags', async ({ page, navigate }) => {


### PR DESCRIPTION
## Summary

- Adds assertions for hero subheading, hero image (via alt text), "Latest posts" heading, at least one post list item, and "View all posts" link
- All text assertions use `t()` translation keys, consistent with the existing pattern
- Keeps the existing hero heading assertion

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced homepage end-to-end test coverage with added visibility assertions for key page elements: hero subheading, hero image alt text, latest posts section heading, first latest-post item, and the “view all” link label.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/M-Kolacz/michalkolacz.com/pull/90)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->