### PR TITLE
refactor: merge and rewrite blog listing E2E tests

### DIFF
--- a/tests/e2e/blog.test.ts
+++ b/tests/e2e/blog.test.ts
@@ -41,7 +41,7 @@ test('Blog post page has correct OG meta tags', async ({ page, navigate }) => {
 	)
 })
 
-test('Blog listing page has OG meta tags', async ({ page, navigate }) => {
+test('Blog listing page has correct meta tags', async ({ page, navigate }) => {
 	await navigate('/blog')
 
 	await expect(getMetaTag(page, 'og:title')).toHaveAttribute(
@@ -52,6 +52,10 @@ test('Blog listing page has OG meta tags', async ({ page, navigate }) => {
 		'content',
 		'website',
 	)
+	await expect(getMetaTag(page, 'og:image')).toHaveAttribute(
+		'content',
+		/\/og-image\.png$/,
+	)
 })
 
 test('Blog listing page displays published posts', async ({
@@ -60,23 +64,13 @@ test('Blog listing page displays published posts', async ({
 }) => {
 	await navigate('/blog')
 
-	await expect(page.getByRole('heading', { level: 1 })).toHaveText('Blog')
+	await expect(page.getByRole('heading', { level: 1 })).toContainText('Blog')
 
-	const postLink = page.getByRole('link', {
-		name: /Visual Regression Testing with Storybook, Playwright, and Docker/,
-	})
-	await expect(postLink).toBeVisible()
+	const postLinks = page.getByRole('link').filter({ hasText: /.+/ })
+	await expect(postLinks.first()).toBeVisible()
 
-	await expect(postLink).toContainText('April 14, 2026')
-	await expect(postLink).toContainText('How I catch unintended UI changes')
-
-	await postLink.click()
-	await expect(page).toHaveURL(/\/blog\/visual-regression-testing$/)
-	await expect(
-		page.getByRole('heading', {
-			name: /Visual Regression Testing with Storybook, Playwright, and Docker/,
-		}),
-	).toBeVisible()
+	await postLinks.first().click()
+	await expect(page).toHaveURL(/\/blog\/[^/]+$/)
 })
 
 test('Blog post page displays banner image, title, date, and reading time', async ({
@@ -146,15 +140,6 @@ test('Blog post page has JSON-LD structured data', async ({
 	expect(parsed['@type']).toBe('Article')
 	expect(parsed.headline).toContain('Visual Regression Testing')
 	expect((parsed.author as Record<string, string>)?.name).toBe('Michal Kolacz')
-})
-
-test('Blog listing page has og:image meta tag', async ({ page, navigate }) => {
-	await navigate('/blog')
-
-	await expect(getMetaTag(page, 'og:image')).toHaveAttribute(
-		'content',
-		/\/og-image\.png$/,
-	)
 })
 
 test('Sitemap includes blog index and blog post URLs', async ({

--- a/tests/e2e/blog.test.ts
+++ b/tests/e2e/blog.test.ts
@@ -65,8 +65,9 @@ test('Blog listing page displays published posts', async ({
 	await navigate('/blog')
 
 	await expect(page.getByRole('heading', { level: 1 })).toContainText('Blog')
+	const list = page.getByRole('list')
 
-	const postLinks = page.getByRole('link').filter({ hasText: /.+/ })
+	const postLinks = list.getByRole('link').filter({ hasText: /.+/ })
 	await expect(postLinks.first()).toBeVisible()
 
 	await postLinks.first().click()
@@ -119,7 +120,6 @@ test('Blog post headings have anchor links', async ({ page, navigate }) => {
 	})
 	await expect(heading).toBeVisible()
 
-	// rehype-slug adds id, rehype-autolink-headings wraps content in <a>
 	const anchor = heading.getByRole('link')
 	await expect(anchor).toHaveAttribute('href', '#the-problem-with-ui-changes')
 })
@@ -135,11 +135,15 @@ test('Blog post page has JSON-LD structured data', async ({
 	await expect(jsonLd).toHaveCount(1)
 
 	const content = await jsonLd.textContent()
-	const parsed = JSON.parse(content ?? '{}') as Record<string, unknown>
+	const parsed = JSON.parse(content ?? '{}') as {
+		'@type': string
+		headline: string
+		author: { name: string }
+	}
 
 	expect(parsed['@type']).toBe('Article')
 	expect(parsed.headline).toContain('Visual Regression Testing')
-	expect((parsed.author as Record<string, string>)?.name).toBe('Michal Kolacz')
+	expect(parsed.author.name).toBe('Michal Kolacz')
 })
 
 test('Sitemap includes blog index and blog post URLs', async ({


### PR DESCRIPTION
## Summary

- Merges `'Blog listing page has OG meta tags'` and `'Blog listing page has og:image meta tag'` into a single `'Blog listing page has correct meta tags'` test with one `navigate('/blog')` call
- Rewrites `'Blog listing page displays published posts'` to assert structure and navigation behavior instead of hardcoded post title, date, and description

Closes #84

## Test plan

- [ ] `Blog listing page has correct meta tags` asserts `og:title`, `og:type`, and `og:image` in one navigation
- [ ] `Blog listing page displays published posts` asserts `h1` contains "Blog", at least one post link is visible, and clicking it navigates to `/blog/:slug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined end-to-end blog tests: renamed coverage for clarity, tightened og:image validation to match the expected image URL pattern, and consolidated duplicate meta-tag checks.
  * Updated navigation assertions to verify generic blog slug routing rather than specific post text/headings.
  * Adjusted JSON-LD parsing and kept key assertions for type, headline content, and author name; removed a small inline comment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/M-Kolacz/michalkolacz.com/pull/91)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->